### PR TITLE
Fix base flywheel recipes

### DIFF
--- a/src/main/resources/data/create/recipes/crafting/kinetics/flywheel.json
+++ b/src/main/resources/data/create/recipes/crafting/kinetics/flywheel.json
@@ -1,13 +1,13 @@
 {
   "type": "minecraft:crafting_shaped",
   "pattern": [
-    "C",
-    "A",
-    "C"
+    "CCC",
+    "CAC",
+    "CCC"
   ],
   "key": {
     "C": {
-      "tag": "forge:ingots/brass"
+      "tag": "c:brass_ingots"
     },
     "A": {
       "item": "create:shaft"

--- a/src/main/resources/data/extendedflywheels/recipes/flywheel.json
+++ b/src/main/resources/data/extendedflywheels/recipes/flywheel.json
@@ -7,7 +7,7 @@
   ],
   "key": {
     "C": {
-      "tag": "forge:ingots/brass"
+      "tag": "c:brass_ingots"
     },
     "A": {
       "item": "create:andesite_alloy"

--- a/src/main/resources/data/extendedflywheels/recipes/iron_flywheel.json
+++ b/src/main/resources/data/extendedflywheels/recipes/iron_flywheel.json
@@ -7,7 +7,7 @@
   ],
   "key": {
     "C": {
-      "tag": "forge:ingots/iron"
+      "tag": "c:iron_ingots"
     },
     "A": {
       "item": "create:andesite_alloy"

--- a/src/main/resources/data/extendedflywheels/recipes/steel_flywheel.json
+++ b/src/main/resources/data/extendedflywheels/recipes/steel_flywheel.json
@@ -7,7 +7,7 @@
   ],
   "key": {
     "C": {
-      "tag": "forge:ingots/steel"
+      "tag": "c:steel_ingots"
     },
     "A": {
       "item": "create:andesite_alloy"


### PR DESCRIPTION
Change recipes that were still using the `forge:ingots/*` tags to use `c:*_ingots` tag instead